### PR TITLE
install libradiotap.so and libnan.so

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,3 +16,5 @@ add_subdirectory(daemon)
 
 #add_subdirectory(googletest)
 #add_subdirectory(tests)
+
+install(TARGETS radiotap DESTINATION lib)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,3 +46,5 @@ target_sources(nan PRIVATE
 target_include_directories(nan PRIVATE ${CMAKE_SOURCE_DIR}/radiotap)
 
 target_link_libraries(nan radiotap)
+
+install(TARGETS nan DESTINATION lib)


### PR DESCRIPTION
`libradiotap.so` and `libnan.so` need to be installed on the target as they are used by the `nan_daemon`.